### PR TITLE
Suspend function support and default Call ApiResponse

### DIFF
--- a/Flower/build.gradle.kts
+++ b/Flower/build.gradle.kts
@@ -64,7 +64,7 @@ dependencies {
     implementation("androidx.core:core-ktx:1.3.0")
 
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:${coroutinesVersion}")
-    implementation("com.squareup.retrofit2:retrofit:${retrofitVersion}")
+    api("com.squareup.retrofit2:retrofit:${retrofitVersion}")
 
     testImplementation("junit:junit:4.13")
     androidTestImplementation("androidx.test.ext:junit:1.1.1")

--- a/Flower/src/main/java/com/hadiyarajesh/flower/NetworkBoundResource.kt
+++ b/Flower/src/main/java/com/hadiyarajesh/flower/NetworkBoundResource.kt
@@ -8,12 +8,12 @@ import kotlinx.coroutines.flow.*
  */
 @ExperimentalCoroutinesApi
 inline fun <DB, REMOTE> networkBoundResource(
-    crossinline fetchFromLocal: () -> Flow<DB>,
-    crossinline shouldFetchFromRemote: (DB?) -> Boolean = { true },
-    crossinline fetchFromRemote: () -> Flow<ApiResponse<REMOTE>>,
-    crossinline processRemoteResponse: (response: ApiSuccessResponse<REMOTE>) -> Unit = { Unit },
-    crossinline saveRemoteData: (REMOTE) -> Unit = { Unit },
-    crossinline onFetchFailed: (errorBody: String?, statusCode: Int) -> Unit = { _: String?, _: Int -> Unit }
+    crossinline fetchFromLocal: suspend () -> Flow<DB>,
+    crossinline shouldFetchFromRemote: suspend (DB?) -> Boolean = { true },
+    crossinline fetchFromRemote: suspend () -> Flow<ApiResponse<REMOTE>>,
+    crossinline processRemoteResponse: suspend (response: ApiSuccessResponse<REMOTE>) -> Unit = { Unit },
+    crossinline saveRemoteData: suspend (REMOTE) -> Unit = { Unit },
+    crossinline onFetchFailed: suspend (errorBody: String?, statusCode: Int) -> Unit = { _: String?, _: Int -> Unit }
 ) = flow<Resource<DB>> {
 
     emit(Resource.loading(null))
@@ -43,6 +43,8 @@ inline fun <DB, REMOTE> networkBoundResource(
                         )
                     })
                 }
+
+                else -> { }
             }
         }
     } else {

--- a/Flower/src/main/java/com/hadiyarajesh/flower/NetworkBoundResource.kt
+++ b/Flower/src/main/java/com/hadiyarajesh/flower/NetworkBoundResource.kt
@@ -11,9 +11,9 @@ inline fun <DB, REMOTE> networkBoundResource(
     crossinline fetchFromLocal: suspend () -> Flow<DB>,
     crossinline shouldFetchFromRemote: suspend (DB?) -> Boolean = { true },
     crossinline fetchFromRemote: suspend () -> Flow<ApiResponse<REMOTE>>,
-    crossinline processRemoteResponse: suspend (response: ApiSuccessResponse<REMOTE>) -> Unit = { Unit },
+    crossinline processRemoteResponse: (response: ApiSuccessResponse<REMOTE>) -> Unit = { Unit },
     crossinline saveRemoteData: suspend (REMOTE) -> Unit = { Unit },
-    crossinline onFetchFailed: suspend (errorBody: String?, statusCode: Int) -> Unit = { _: String?, _: Int -> Unit }
+    crossinline onFetchFailed: (errorBody: String?, statusCode: Int) -> Unit = { _: String?, _: Int -> Unit }
 ) = flow<Resource<DB>> {
 
     emit(Resource.loading(null))

--- a/Flower/src/main/java/com/hadiyarajesh/flower/calladpater/CallDelegate.kt
+++ b/Flower/src/main/java/com/hadiyarajesh/flower/calladpater/CallDelegate.kt
@@ -1,0 +1,25 @@
+package com.hadiyarajesh.flower.calladpater
+
+import okhttp3.Request
+import okio.Timeout
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
+
+abstract class CallDelegate<TIn, TOut>(
+    protected val proxy: Call<TIn>
+) : Call<TOut> {
+
+    override fun execute(): Response<TOut> = throw NotImplementedError()
+    override fun enqueue(callback: Callback<TOut>) = enqueueImplementation(callback)
+    override fun clone(): Call<TOut> = cloneImplementation()
+
+    override fun cancel() = proxy.cancel()
+    override fun request(): Request = proxy.request()
+    override fun timeout(): Timeout = proxy.timeout()
+    override fun isExecuted(): Boolean = proxy.isExecuted
+    override fun isCanceled(): Boolean = proxy.isCanceled
+
+    abstract fun enqueueImplementation(callback: Callback<TOut>)
+    abstract fun cloneImplementation(): Call<TOut>
+}

--- a/Flower/src/main/java/com/hadiyarajesh/flower/calladpater/FlowCallAdapter.kt
+++ b/Flower/src/main/java/com/hadiyarajesh/flower/calladpater/FlowCallAdapter.kt
@@ -10,14 +10,14 @@ import retrofit2.CallAdapter
 import retrofit2.awaitResponse
 import java.lang.reflect.Type
 
-class FlowCallAdapter<T>(
+class FlowCallAdapter(
     private val responseType: Type
-) : CallAdapter<T, Flow<ApiResponse<T>>> {
+) : CallAdapter<Type, Flow<ApiResponse<Type>>> {
 
     override fun responseType() = responseType
 
     @ExperimentalCoroutinesApi
-    override fun adapt(call: Call<T>): Flow<ApiResponse<T>> = flow {
+    override fun adapt(call: Call<Type>): Flow<ApiResponse<Type>> = flow {
 
         val response = call.awaitResponse()
         emit(ApiResponse.create(response))

--- a/Flower/src/main/java/com/hadiyarajesh/flower/calladpater/FlowCallAdapterFactory.kt
+++ b/Flower/src/main/java/com/hadiyarajesh/flower/calladpater/FlowCallAdapterFactory.kt
@@ -2,6 +2,7 @@ package com.hadiyarajesh.flower.calladpater
 
 import com.hadiyarajesh.flower.ApiResponse
 import kotlinx.coroutines.flow.Flow
+import retrofit2.Call
 
 import retrofit2.CallAdapter
 import retrofit2.Retrofit
@@ -13,21 +14,30 @@ class FlowCallAdapterFactory : CallAdapter.Factory() {
         returnType: Type,
         annotations: Array<Annotation>,
         retrofit: Retrofit
-    ): CallAdapter<*, *>? {
-        if (getRawType(returnType) != Flow::class.java) {
-            return null
+    ): CallAdapter<*, *>? = when (getRawType(returnType)) {
+        Flow::class.java -> {
+            val observableType = getParameterUpperBound(0, returnType as ParameterizedType)
+            require(observableType is ParameterizedType) { "resource must be parameterized" }
+            val rawObservableType = getRawType(observableType)
+            require(rawObservableType == ApiResponse::class.java) { "type must be a resource" }
+            val bodyType = getParameterUpperBound(0, observableType)
+            FlowCallAdapter(bodyType)
         }
-        val observableType = getParameterUpperBound(0, returnType as ParameterizedType)
-        val rawObservableType = getRawType(observableType)
-        require(rawObservableType == ApiResponse::class.java) { "type must be a resource" }
-        require(observableType is ParameterizedType) { "resource must be parameterized" }
-        val bodyType = getParameterUpperBound(0, observableType)
-        return FlowCallAdapter<Any>(bodyType)
+        Call::class.java -> {
+            val callType = getParameterUpperBound(0, returnType as ParameterizedType)
+            when (getRawType(callType)) {
+                Result::class.java -> {
+                    val resultType = getParameterUpperBound(0, callType as ParameterizedType)
+                    ResultAdapter(resultType)
+                }
+                else -> null
+            }
+        }
+        else -> null
     }
 
     companion object {
         @JvmStatic
-        fun create() =
-            FlowCallAdapterFactory()
+        fun create() = FlowCallAdapterFactory()
     }
 }

--- a/Flower/src/main/java/com/hadiyarajesh/flower/calladpater/FlowCallAdapterFactory.kt
+++ b/Flower/src/main/java/com/hadiyarajesh/flower/calladpater/FlowCallAdapterFactory.kt
@@ -26,7 +26,7 @@ class FlowCallAdapterFactory : CallAdapter.Factory() {
         Call::class.java -> {
             val callType = getParameterUpperBound(0, returnType as ParameterizedType)
             when (getRawType(callType)) {
-                Result::class.java -> {
+                ApiResponse::class.java -> {
                     val resultType = getParameterUpperBound(0, callType as ParameterizedType)
                     ResultAdapter(resultType)
                 }

--- a/Flower/src/main/java/com/hadiyarajesh/flower/calladpater/ResultAdapter.kt
+++ b/Flower/src/main/java/com/hadiyarajesh/flower/calladpater/ResultAdapter.kt
@@ -1,0 +1,13 @@
+package com.hadiyarajesh.flower.calladpater
+
+import com.hadiyarajesh.flower.ApiResponse
+import retrofit2.Call
+import retrofit2.CallAdapter
+import java.lang.reflect.Type
+
+class ResultAdapter(
+    private val type: Type
+) : CallAdapter<Type, Call<ApiResponse<Type>>> {
+    override fun adapt(call: Call<Type>): Call<ApiResponse<Type>> = ResultCall(call)
+    override fun responseType(): Type = type
+}

--- a/Flower/src/main/java/com/hadiyarajesh/flower/calladpater/ResultCall.kt
+++ b/Flower/src/main/java/com/hadiyarajesh/flower/calladpater/ResultCall.kt
@@ -1,0 +1,21 @@
+package com.hadiyarajesh.flower.calladpater
+
+import com.hadiyarajesh.flower.ApiResponse
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
+
+class ResultCall<T>(proxy: Call<T>) : CallDelegate<T, ApiResponse<T>>(proxy) {
+
+    override fun enqueueImplementation(callback: Callback<ApiResponse<T>>) = proxy.enqueue(object : Callback<T> {
+        override fun onResponse(call: Call<T>, response: Response<T>) {
+            callback.onResponse(this@ResultCall, Response.success(ApiResponse.create(response)))
+        }
+
+        override fun onFailure(call: Call<T>, t: Throwable) {
+            callback.onResponse(this@ResultCall, Response.success(ApiResponse.create(t)))
+        }
+    })
+
+    override fun cloneImplementation(): Call<ApiResponse<T>> = ResultCall(proxy.clone())
+}

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ fun getSomething(): Flow<Resource<YourModelclass>> {
         fetchFromRemote = { apiInterface.getFromRemote() },
         processRemoteResponse = { },
         saveRemoteData = { yourDaoclass.saveYourData(it) },
-        onFetchFailed {-, _ -> }
+        onFetchFailed {_, _ -> }
     ).flowOn(Dispatchers.IO)
 }
 
@@ -70,6 +70,7 @@ val someVariable: LiveData<Resource<YourModelClass>> = repository.getSomething()
         Resource.Status.ERROR -> {
             Resource.error(it.message!!, null)
         }
+    }
 }.asLiveData(viewModelScope.coroutineContext)
 
 ```


### PR DESCRIPTION
- added possibility to call suspend functions in networkBoundResource
- provide retrofit to root project to ensure working with same version without compatibility issues
- removed passing type Any to FlowCallAdapter
- fixed some parsing with requirement in FlowCallAdapterFactory when using flow
- provide ApiResponse for default calls (useful when calling such functions without handling in DB but relying on same service)
- fixed README typos