### PR TITLE
Fixed maven publishing

### DIFF
--- a/flower-core/build.gradle.kts
+++ b/flower-core/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.vanniktech.maven.publish.SonatypeHost
+
 plugins {
     kotlin("multiplatform")
     id("com.android.library")
@@ -12,6 +14,9 @@ repositories {
     mavenCentral()
     gradlePluginPortal()
 }
+
+group = "io.github.hadiyarajesh.flower-core"
+version = "3.0.0"
 
 android {
     compileSdk = 32
@@ -61,7 +66,7 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                api("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.3")
+                api("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
             }
         }
         val jvmMain by getting
@@ -80,57 +85,33 @@ kotlin {
     }
 }
 
-publishing {
-    publications {
-        create<MavenPublication>("default") {
-            artifact(tasks["sourcesJar"])
+mavenPublishing {
+    publishToMavenCentral(SonatypeHost.S01)
+    signAllPublications()
 
-            pom {
-                name.set(project.name)
-                description.set("Flower Core Library")
-                url.set("https://github.com/hadiyarajesh/flower")
+    pom {
+        name.set(project.name)
+        description.set("Flower Core Library")
+        url.set("https://github.com/hadiyarajesh/flower")
 
-                licenses {
-                    license {
-                        name.set("MIT")
-                        url.set("https://github.com/hadiyarajesh/flower/blob/master/LICENSE")
-                    }
-                }
-                scm {
-                    url.set("https://github.com/hadiyarajesh/flower")
-                    connection.set("scm:git:git://github.com/hadiyarajesh/flower.git")
-                }
-                developers {
-                    developer {
-                        name.set("Rajesh Hadiya")
-                        url.set("https://github.com/hadiyarajesh")
-                    }
-                    developer {
-                        name.set("Jeff Retz")
-                        url.set("https://github.com/DatL4g")
-                    }
-                }
+        licenses {
+            license {
+                name.set("MIT")
+                url.set("https://github.com/hadiyarajesh/flower/blob/master/LICENSE")
             }
         }
-    }
-
-    repositories {
-        if (
-            hasProperty("sonatypeUsername") &&
-            hasProperty("sonatypePassword") &&
-            hasProperty("sonatypeSnapshotUrl") &&
-            hasProperty("sonatypeReleaseUrl")
-        ) {
-            maven {
-                val url = when {
-                    "SNAPSHOT" in version.toString() -> property("sonatypeSnapshotUrl")
-                    else -> property("sonatypeReleaseUrl")
-                } as String
-                setUrl(url)
-                credentials {
-                    username = property("sonatypeUsername") as String
-                    password = property("sonatypePassword") as String
-                }
+        scm {
+            url.set("https://github.com/hadiyarajesh/flower")
+            connection.set("scm:git:git://github.com/hadiyarajesh/flower.git")
+        }
+        developers {
+            developer {
+                name.set("Rajesh Hadiya")
+                url.set("https://github.com/hadiyarajesh")
+            }
+            developer {
+                name.set("Jeff Retz")
+                url.set("https://github.com/DatL4g")
             }
         }
     }

--- a/flower-ktorfit/build.gradle.kts
+++ b/flower-ktorfit/build.gradle.kts
@@ -6,6 +6,9 @@ plugins {
     id("com.vanniktech.maven.publish")
 }
 
+group = "io.github.hadiyarajesh.flower-ktorfit"
+version = "3.0.0"
+
 android {
     compileSdk = 32
 
@@ -74,57 +77,33 @@ kotlin {
     }
 }
 
-publishing {
-    publications {
-        create<MavenPublication>("default") {
-            artifact(tasks["sourcesJar"])
+mavenPublishing {
+    publishToMavenCentral(com.vanniktech.maven.publish.SonatypeHost.S01)
+    signAllPublications()
 
-            pom {
-                name.set(project.name)
-                description.set("Flower Ktorfit Library")
-                url.set("https://github.com/hadiyarajesh/flower")
+    pom {
+        name.set(project.name)
+        description.set("Flower Ktorfit Library")
+        url.set("https://github.com/hadiyarajesh/flower")
 
-                licenses {
-                    license {
-                        name.set("MIT")
-                        url.set("https://github.com/hadiyarajesh/flower/blob/master/LICENSE")
-                    }
-                }
-                scm {
-                    url.set("https://github.com/hadiyarajesh/flower")
-                    connection.set("scm:git:git://github.com/hadiyarajesh/flower.git")
-                }
-                developers {
-                    developer {
-                        name.set("Rajesh Hadiya")
-                        url.set("https://github.com/hadiyarajesh")
-                    }
-                    developer {
-                        name.set("Jeff Retz")
-                        url.set("https://github.com/DatL4g")
-                    }
-                }
+        licenses {
+            license {
+                name.set("MIT")
+                url.set("https://github.com/hadiyarajesh/flower/blob/master/LICENSE")
             }
         }
-    }
-
-    repositories {
-        if (
-            hasProperty("sonatypeUsername") &&
-            hasProperty("sonatypePassword") &&
-            hasProperty("sonatypeSnapshotUrl") &&
-            hasProperty("sonatypeReleaseUrl")
-        ) {
-            maven {
-                val url = when {
-                    "SNAPSHOT" in version.toString() -> property("sonatypeSnapshotUrl")
-                    else -> property("sonatypeReleaseUrl")
-                } as String
-                setUrl(url)
-                credentials {
-                    username = property("sonatypeUsername") as String
-                    password = property("sonatypePassword") as String
-                }
+        scm {
+            url.set("https://github.com/hadiyarajesh/flower")
+            connection.set("scm:git:git://github.com/hadiyarajesh/flower.git")
+        }
+        developers {
+            developer {
+                name.set("Rajesh Hadiya")
+                url.set("https://github.com/hadiyarajesh")
+            }
+            developer {
+                name.set("Jeff Retz")
+                url.set("https://github.com/DatL4g")
             }
         }
     }

--- a/flower-retrofit/build.gradle.kts
+++ b/flower-retrofit/build.gradle.kts
@@ -6,6 +6,9 @@ plugins {
     id("com.vanniktech.maven.publish")
 }
 
+group = "io.github.hadiyarajesh.flower-retrofit"
+version = "3.0.0"
+
 android {
     compileSdk = 32
 
@@ -50,57 +53,33 @@ tasks.register<Jar>("androidSourcesJar") {
     }
 }
 
-publishing {
-    publications {
-        create<MavenPublication>("default") {
-            artifact(tasks["androidSourcesJar"])
+mavenPublishing {
+    publishToMavenCentral(com.vanniktech.maven.publish.SonatypeHost.S01)
+    signAllPublications()
 
-            pom {
-                name.set(project.name)
-                description.set("Flower Retrofit Library")
-                url.set("https://github.com/hadiyarajesh/flower")
+    pom {
+        name.set(project.name)
+        description.set("Flower Retrofit Library")
+        url.set("https://github.com/hadiyarajesh/flower")
 
-                licenses {
-                    license {
-                        name.set("MIT")
-                        url.set("https://github.com/hadiyarajesh/flower/blob/master/LICENSE")
-                    }
-                }
-                scm {
-                    url.set("https://github.com/hadiyarajesh/flower")
-                    connection.set("scm:git:git://github.com/hadiyarajesh/flower.git")
-                }
-                developers {
-                    developer {
-                        name.set("Rajesh Hadiya")
-                        url.set("https://github.com/hadiyarajesh")
-                    }
-                    developer {
-                        name.set("Jeff Retz")
-                        url.set("https://github.com/DatL4g")
-                    }
-                }
+        licenses {
+            license {
+                name.set("MIT")
+                url.set("https://github.com/hadiyarajesh/flower/blob/master/LICENSE")
             }
         }
-    }
-
-    repositories {
-        if (
-            hasProperty("sonatypeUsername") &&
-            hasProperty("sonatypePassword") &&
-            hasProperty("sonatypeSnapshotUrl") &&
-            hasProperty("sonatypeReleaseUrl")
-        ) {
-            maven {
-                val url = when {
-                    "SNAPSHOT" in version.toString() -> property("sonatypeSnapshotUrl")
-                    else -> property("sonatypeReleaseUrl")
-                } as String
-                setUrl(url)
-                credentials {
-                    username = property("sonatypeUsername") as String
-                    password = property("sonatypePassword") as String
-                }
+        scm {
+            url.set("https://github.com/hadiyarajesh/flower")
+            connection.set("scm:git:git://github.com/hadiyarajesh/flower.git")
+        }
+        developers {
+            developer {
+                name.set("Rajesh Hadiya")
+                url.set("https://github.com/hadiyarajesh")
+            }
+            developer {
+                name.set("Jeff Retz")
+                url.set("https://github.com/DatL4g")
             }
         }
     }


### PR DESCRIPTION
The publishing process of the gradle plugin changed.

I fixed the modules.
You need to publish the modules separatly like this:

```bash
./gradlew :flower-core:publish
./gradlew :flower-retrofit:publish
./gradlew :flower-ktorfit:publish
```

I've already tested it (under my repository) and the packages are available like this:

```gradle
implementation("dev.datlag.flower-ktorfit:flower-core:3.0.0-beta02")
implementation("dev.datlag.flower-ktorfit:flower-retrofit:3.0.0-beta02")
implementation("dev.datlag.flower-ktorfit:flower-ktorfit:3.0.0-beta02")
```

Of course you only need either the Retrofit package or the Ktorfit package.
The core module is referenced and available in these.