### PR TITLE
Removed native target as Ktorfit is not available for Windows

### DIFF
--- a/flower-core/build.gradle.kts
+++ b/flower-core/build.gradle.kts
@@ -45,6 +45,9 @@ kotlin {
     android {
         publishLibraryVariants("release", "debug")
     }
+    macosX64()
+    watchosArm64()
+    watchosX64()
     iosX64()
     iosArm64()
     iosSimulatorArm64()
@@ -54,13 +57,10 @@ kotlin {
         nodejs()
         binaries.executable()
     }
-    val hostOs = System.getProperty("os.name")
-    val isMingwX64 = hostOs.startsWith("Windows")
-    val nativeTarget = when {
-        hostOs == "Mac OS X" -> macosX64("native")
-        hostOs == "Linux" -> linuxX64("native")
-        isMingwX64 -> mingwX64("native")
-        else -> throw GradleException("Host OS is not supported in Kotlin/Native.")
+    linuxX64 {
+        binaries {
+            executable()
+        }
     }
 
     sourceSets {
@@ -69,9 +69,9 @@ kotlin {
                 api("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
             }
         }
+        val linuxX64Main by getting
         val jvmMain by getting
         val jsMain by getting
-        val nativeMain by getting
 
         val iosX64Main by getting
         val iosArm64Main by getting

--- a/flower-ktorfit/build.gradle.kts
+++ b/flower-ktorfit/build.gradle.kts
@@ -36,6 +36,9 @@ kotlin {
     android {
         publishLibraryVariants("release", "debug")
     }
+    macosX64()
+    watchosArm64()
+    watchosX64()
     iosX64()
     iosArm64()
     iosSimulatorArm64()
@@ -45,13 +48,10 @@ kotlin {
         nodejs()
         binaries.executable()
     }
-    val hostOs = System.getProperty("os.name")
-    val isMingwX64 = hostOs.startsWith("Windows")
-    val nativeTarget = when {
-        hostOs == "Mac OS X" -> macosX64("native")
-        hostOs == "Linux" -> linuxX64("native")
-        isMingwX64 -> mingwX64("native")
-        else -> throw GradleException("Host OS is not supported in Kotlin/Native.")
+    linuxX64 {
+        binaries {
+            executable()
+        }
     }
 
     sourceSets {
@@ -62,7 +62,7 @@ kotlin {
             }
         }
         val jvmMain by getting
-        val nativeMain by getting
+        val linuxX64Main by getting
         val jsMain by getting
 
         val iosX64Main by getting


### PR DESCRIPTION
This fixes the build issue on Windows.
It contains all platforms now that can be used.